### PR TITLE
Optimize git stash count

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -256,7 +256,7 @@ if is-at-least 4.3.11; then
         fi
 
         local stash
-        stash=$(cd $(git rev-parse --git-dir); wc -l logs/refs/stash | awk '{print $1}')
+        stash=$(wc -l "$(git rev-parse --git-dir)/logs/refs/stash" | awk '{print $1}')
         if [[ "${stash}" -gt 0 ]]; then
             # misc (%m) に追加
             hook_com[misc]+=":S${stash}"

--- a/.zshrc
+++ b/.zshrc
@@ -256,7 +256,7 @@ if is-at-least 4.3.11; then
         fi
 
         local stash
-        stash=$(command git stash list 2>/dev/null | wc -l | tr -d ' ')
+        stash=$(cd $(git rev-parse --git-dir); wc -l logs/refs/stash | awk '{print $1}')
         if [[ "${stash}" -gt 0 ]]; then
             # misc (%m) に追加
             hook_com[misc]+=":S${stash}"


### PR DESCRIPTION
In ruby/ruby repository.

```console
$ time (echo $(command git stash list 2>/dev/null | wc -l | tr -d ' '))
2
( echo $(command git stash list 2>/dev/null | wc -l | tr -d ' '); )  0.03s user 0.04s system 9% cpu 0.680 total

$ time (echo $(wc -l "$(git rev-parse --git-dir)/logs/refs/stash" | awk '{print $1}'))
2
( echo ; )  0.00s user 0.01s system 19% cpu 0.060 total
```